### PR TITLE
Fix: MethodImplementationTranslator was using the wrong class factory

### DIFF
--- a/src/main/java/patdroid/smali/MethodImplementationTranslator.java
+++ b/src/main/java/patdroid/smali/MethodImplementationTranslator.java
@@ -1135,8 +1135,7 @@ final class MethodImplementationTranslator {
             realArgs[i++] = args[j++];
         for (CharSequence smaliType: mr.getParameterTypes()) {
             realArgs[i++] = args[j++];
-            final ClassInfo ci = scope.findOrCreateClass(smaliType.toString());
-            if (ci == scope.primitiveLong || ci == scope.primitiveDouble)
+            if (smaliType.equals("J") || smaliType.equals("D"))
                 ++j;
         }
         checkState(j == args.length, "argument size mismatch");


### PR DESCRIPTION
MethodImplementationTranslator was using the wrong class factory (java instead of dalvik). Hardcoded long and double types.